### PR TITLE
Add Google Fonts and style updates

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,21 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+export default function Document() {
+  return (
+    <Html>
+      <Head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Lato:wght@400;700&family=Playfair+Display:wght@400;700&display=swap"
+          rel="stylesheet"
+        />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}
+

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,26 @@
-body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
-nav { padding: 1rem; background: #333; color: white; }
-a { color: inherit; margin-right: 1rem; }
-.container { padding: 1rem; }
+body {
+  font-family: 'Lato', Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Playfair Display', Georgia, serif;
+}
+
+nav {
+  padding: 1rem;
+  background: #333;
+  color: white;
+}
+
+nav a {
+  font-family: 'Playfair Display', Georgia, serif;
+  color: inherit;
+  margin-right: 1rem;
+}
+
+.container {
+  padding: 1rem;
+}
+


### PR DESCRIPTION
## Summary
- load Google fonts globally using a custom Document
- apply Playfair Display for headings and navigation
- apply Lato for body text

## Testing
- `npm test`
- `npm run test:e2e` *(fails: missing Playwright browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6844892149288329a13dabd6d8f75082