### PR TITLE
Add layout with header and footer

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function Footer() {
+  return (
+    <footer>
+      &copy; 2025 Agentic Commerce
+    </footer>
+  );
+}

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,0 +1,14 @@
+import React from "react";
+import Link from 'next/link';
+
+export default function Header() {
+  return (
+    <header>
+      <nav>
+        <Link href="/">Home</Link>
+        <Link href="/cart">Cart</Link>
+        <Link href="/account">Account</Link>
+      </nav>
+    </header>
+  );
+}

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -1,0 +1,15 @@
+import React from "react";
+import Header from './Header';
+import Footer from './Footer';
+
+export default function Layout({ children }) {
+  return (
+    <>
+      <Header />
+      <main className="container">
+        {children}
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/pages/account.js
+++ b/pages/account.js
@@ -1,12 +1,11 @@
 import React from "react";
-import Nav from '../components/Nav';
+import Layout from '../components/Layout';
 
 export default function Account() {
   return (
-    <div>
-      <Nav />
+    <Layout>
       <h1>My Account</h1>
       <p>Account details would go here.</p>
-    </div>
+    </Layout>
   );
 }

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -1,12 +1,11 @@
 import React from "react";
-import Nav from '../components/Nav';
+import Layout from '../components/Layout';
 import { useCart } from '../lib/cartContext';
 
 export default function Cart() {
   const { items } = useCart();
   return (
-    <div>
-      <Nav />
+    <Layout>
       <h1>Cart</h1>
       {items.length ? (
         items.map((item, idx) => (
@@ -17,6 +16,6 @@ export default function Cart() {
       ) : (
         <p>Cart is empty</p>
       )}
-    </div>
+    </Layout>
   );
 }

--- a/pages/checkout.js
+++ b/pages/checkout.js
@@ -1,12 +1,11 @@
 import React from "react";
-import Nav from '../components/Nav';
+import Layout from '../components/Layout';
 
 export default function Checkout() {
   return (
-    <div>
-      <Nav />
+    <Layout>
       <h1>Checkout</h1>
       <p>Mock checkout page.</p>
-    </div>
+    </Layout>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,17 +1,16 @@
 import React from "react";
 import useSWR from 'swr';
 import ProductList from '../components/ProductList';
-import Nav from '../components/Nav';
+import Layout from '../components/Layout';
 
 const fetcher = url => fetch(url).then(r => r.json());
 
 export default function Home() {
   const { data } = useSWR('http://localhost:3001/api/products', fetcher);
   return (
-    <div>
-      <Nav />
+    <Layout>
       <h1>Store</h1>
       {data ? <ProductList products={data} /> : 'Loading...'}
-    </div>
+    </Layout>
   );
 }

--- a/pages/products/[id].js
+++ b/pages/products/[id].js
@@ -1,7 +1,7 @@
 import React from "react";
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
-import Nav from '../../components/Nav';
+import Layout from '../../components/Layout';
 import { useCart } from '../../lib/cartContext';
 
 const fetcher = url => fetch(url).then(r => r.json());
@@ -15,11 +15,10 @@ export default function ProductDetail() {
   if (!data) return <div>Loading...</div>;
 
   return (
-    <div>
-      <Nav />
+    <Layout>
       <h1>{data.name}</h1>
       <p>{data.description}</p>
       <button onClick={() => addItem(data)}>Add to Cart</button>
-    </div>
+    </Layout>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,7 @@
 body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
 nav { padding: 1rem; background: #333; color: white; }
-a { color: inherit; margin-right: 1rem; }
+nav a { margin-right: 1.5rem; color: inherit; text-decoration: none; }
+nav a:hover { text-decoration: underline; }
+footer { padding: 1rem; background: #eee; text-align: center; }
+a { color: inherit; }
 .container { padding: 1rem; }


### PR DESCRIPTION
## Summary
- create `Header`, `Footer`, and `Layout` components
- style navigation links and add footer styles
- wrap pages with the new `Layout` for consistent layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844892000848329a493608f6033ace0