### PR TITLE
Fix React undefined in _document

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Html, Head, Main, NextScript } from 'next/document';
 
 export default function Document() {


### PR DESCRIPTION
## Summary
- import React in `_document.js` to avoid server error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68433a3636c0832988f7548c3657ed34