### PR TITLE
Update tests for expanded product data

### DIFF
--- a/__tests__/home.test.js
+++ b/__tests__/home.test.js
@@ -2,9 +2,15 @@ import React from "react";
 import { render, screen } from '@testing-library/react';
 import Home from '../pages/index';
 
-jest.mock('swr', () => () => ({ data: [{ id: 1, name: 'Product', price: 1 }] }));
+jest.mock('swr', () => () => ({
+  data: [
+    { id: 1, name: 'Product 1', price: 1, color: 'red' },
+    { id: 2, name: 'Product 2', price: 2, color: 'blue' }
+  ]
+}));
 
-test('renders products', () => {
+test('renders products from API', () => {
   render(<Home />);
-  expect(screen.getByText('Product')).toBeInTheDocument();
+  expect(screen.getByText('Product 1')).toBeInTheDocument();
+  expect(screen.getByText('Product 2')).toBeInTheDocument();
 });

--- a/backend/__tests__/server.test.js
+++ b/backend/__tests__/server.test.js
@@ -4,7 +4,24 @@ const express = require('express');
 // create app similar to server.js
 const app = express();
 app.use(express.json());
-const products = [{ id: 1, name: 'Example Product', description: 'An example product', price: 9.99, image: '/placeholder.png' }];
+const products = [
+  {
+    id: 1,
+    name: 'Example Product',
+    description: 'An example product',
+    price: 9.99,
+    image: '/placeholder.png',
+    color: 'red'
+  },
+  {
+    id: 2,
+    name: 'Second Product',
+    description: 'Another item',
+    price: 19.99,
+    image: '/placeholder.png',
+    color: 'blue'
+  }
+];
 app.get('/api/products', (req, res) => res.json(products));
 app.get('/api/products/:id', (req, res) => {
   const product = products.find(p => p.id === parseInt(req.params.id));
@@ -16,6 +33,14 @@ describe('API', () => {
   it('should list products', async () => {
     const res = await request(app).get('/api/products');
     expect(res.statusCode).toBe(200);
-    expect(res.body.length).toBeGreaterThan(0);
+    expect(res.body.length).toBe(products.length);
+    res.body.forEach(p => expect(p).toHaveProperty('color'));
+  });
+
+  it('should get a single product with color', async () => {
+    const res = await request(app).get('/api/products/1');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('color');
+    expect(res.body.id).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- adjust API test to expect multiple products and verify new `color` field
- update home page unit test for new product data
- verify existing e2e test listing

## Testing
- `npx jest --runInBand`
- `npx playwright test` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684497b8468c8329ad4eb397598c3b50