### PR TITLE
Display product color

### DIFF
--- a/__tests__/home.test.js
+++ b/__tests__/home.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import { render, screen } from '@testing-library/react';
 import Home from '../pages/index';
 
-jest.mock('swr', () => () => ({ data: [{ id: 1, name: 'Product', price: 1 }] }));
+jest.mock('swr', () => () => ({ data: [{ id: 1, name: 'Product', price: 1, color: 'Red' }] }));
 
 test('renders products', () => {
   render(<Home />);

--- a/backend/server.js
+++ b/backend/server.js
@@ -7,7 +7,14 @@ app.use(express.json());
 app.use(cors());
 
 const products = [
-  { id: 1, name: 'Example Product', description: 'An example product', price: 9.99, image: '/placeholder.png' }
+  {
+    id: 1,
+    name: 'Example Product',
+    description: 'An example product',
+    price: 9.99,
+    image: '/placeholder.png',
+    color: 'Red'
+  }
 ];
 
 app.get('/api/products', (req, res) => {

--- a/components/ProductList.js
+++ b/components/ProductList.js
@@ -12,6 +12,9 @@ export default function ProductList({ products }) {
           </Link>
           <h3>{p.name}</h3>
           <p className={styles.price}>${p.price}</p>
+          {p.color && (
+            <p className={styles.color}>Color: {p.color}</p>
+          )}
           <Link href={`/products/${p.id}`}>View</Link>
         </div>
       ))}

--- a/components/ProductList.module.css
+++ b/components/ProductList.module.css
@@ -21,6 +21,11 @@
   margin: 0.5rem 0;
 }
 
+.color {
+  margin: 0.25rem 0;
+  color: #555;
+}
+
 @media (min-width: 600px) {
   .grid {
     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));

--- a/pages/cart.js
+++ b/pages/cart.js
@@ -11,6 +11,7 @@ export default function Cart() {
         items.map((item, idx) => (
           <div key={idx}>
             {item.name} - ${item.price}
+            {item.color && <span> - {item.color}</span>}
           </div>
         ))
       ) : (

--- a/pages/products/[id].js
+++ b/pages/products/[id].js
@@ -28,6 +28,7 @@ export default function ProductDetail() {
       />
       <h1>{data.name}</h1>
       <p>${data.price}</p>
+      {data.color && <p>Color: {data.color}</p>}
       <p>{data.description}</p>
       <button onClick={() => addItem(data)}>Add to Cart</button>
     </Layout>


### PR DESCRIPTION
## Summary
- enhance server mock products with a color field
- show color in product listings and detail page
- include color for items in cart
- add styles for color display
- update unit test mock data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684497b74ba883298ed4831dcc4ef67b