### PR TITLE
Add WebdriverIO test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "backend": "node backend/server.js",
     "test": "jest",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:wdio": "wdio run wdio.conf.js"
   },
   "dependencies": {
     "@playwright/test": "^1.52.0",
@@ -31,7 +32,14 @@
     "jest-environment-jsdom": "^30.0.0-beta.3",
     "playwright": "^1.39.0",
     "supertest": "^6.3.3",
-    "identity-obj-proxy": "^3.0.0"
+    "identity-obj-proxy": "^3.0.0",
+    "webdriverio": "^8.39.0",
+    "@wdio/cli": "^8.39.0",
+    "@wdio/local-runner": "^8.39.0",
+    "@wdio/mocha-framework": "^8.39.0",
+    "@wdio/spec-reporter": "^8.39.0",
+    "@wdio/chromedriver-service": "^8.39.0",
+    "chromedriver": "^125.0.0"
   },
   "jest": {
     "testEnvironment": "jsdom",

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,0 +1,24 @@
+const { spawn } = require('child_process');
+
+let server;
+
+exports.config = {
+  runner: 'local',
+  specs: ['./wdio/specs/**/*.js'],
+  maxInstances: 1,
+  capabilities: [{
+    browserName: 'chrome',
+    'goog:chromeOptions': { args: ['--headless', '--disable-gpu', '--no-sandbox'] }
+  }],
+  logLevel: 'error',
+  framework: 'mocha',
+  reporters: ['spec'],
+  services: ['chromedriver'],
+  mochaOpts: { timeout: 60000 },
+  onPrepare: function () {
+    server = spawn('npm', ['run', 'dev'], { stdio: 'inherit' });
+  },
+  onComplete: function () {
+    if (server) server.kill();
+  }
+};

--- a/wdio/specs/ecommerce.e2e.js
+++ b/wdio/specs/ecommerce.e2e.js
@@ -1,0 +1,29 @@
+const { expect } = require('chai');
+
+describe('E-commerce flow', () => {
+  it('loads home page and shows products', async () => {
+    await browser.url('http://localhost:3000');
+    await expect(await $("h1=Store")).to.be.displayed;
+    const items = await $$("div.item");
+    expect(items.length).to.be.greaterThan(0);
+  });
+
+  it('opens product detail and adds to cart', async () => {
+    await $("div.item a").click();
+    await expect(await $("button=Add to Cart")).to.be.displayed;
+    await $("button=Add to Cart").click();
+    await browser.url('http://localhost:3000/cart');
+    await expect(await $("h1=Cart")).to.be.displayed;
+    await expect(await $('div')).to.have.textContaining('Example Product');
+  });
+
+  it('navigates to checkout', async () => {
+    await browser.url('http://localhost:3000/checkout');
+    await expect(await $("h1=Checkout")).to.be.displayed;
+  });
+
+  it('views account page', async () => {
+    await browser.url('http://localhost:3000/account');
+    await expect(await $("h1=My Account")).to.be.displayed;
+  });
+});


### PR DESCRIPTION
## Summary
- install WebdriverIO related packages
- add `wdio.conf.js` to launch the dev servers and Chrome headless
- add E2E flow covering home, product detail, cart, checkout and account pages
- expose `npm run test:wdio` script

## Testing
- `npm test` *(fails: Unable to find text 'Product 1')*
- `npm run test:e2e`
- `npm run test:wdio` *(fails: wdio not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f7c1d4848329b6c67839e8175693