### PR TITLE
Add env example and use env URL

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,8 @@
+# Example environment variables for local development
+NEXT_PUBLIC_API_URL=http://localhost:3001
+CT_API_URL=https://api.europe-west1.gcp.commercetools.com
+CT_CLIENT_ID=your-commercetools-client-id
+CT_CLIENT_SECRET=your-commercetools-client-secret
+SHOPIFY_URL=https://yourshop.myshopify.com/api/graphql
+SHOPIFY_TOKEN=your-shopify-token
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .next
 test-results
+.env.local

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ npm run dev
 
 This starts the Express API on port 3001 and Next.js on port 3000.
 
+### Environment Variables
+
+Copy `.env.local.example` to `.env.local` and fill in the values for your environment. The frontend uses `NEXT_PUBLIC_API_URL` to know where the API is running.
+
 Run tests:
 
 ```bash

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -7,9 +7,10 @@ import Layout from '../components/Layout';
  */
 
 const fetcher = url => fetch(url).then(r => r.json());
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
 export default function Home() {
-  const { data } = useSWR('http://localhost:3001/api/products', fetcher);
+  const { data } = useSWR(`${API_BASE_URL}/api/products`, fetcher);
   return (
     <Layout>
       <h1>Store</h1>

--- a/src/app/products/[id]/page.js
+++ b/src/app/products/[id]/page.js
@@ -9,12 +9,13 @@ import { useCart } from '../../../lib/cartContext';
  */
 
 const fetcher = url => fetch(url).then(r => r.json());
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 
 
 export default function ProductDetail() {
   const router = useRouter();
   const { id } = router.query;
-  const { data } = useSWR(id ? `http://localhost:3001/api/products/${id}` : null, fetcher);
+  const { data } = useSWR(id ? `${API_BASE_URL}/api/products/${id}` : null, fetcher);
   const { addItem } = useCart();
 
   if (!data) return (


### PR DESCRIPTION
## Summary
- add `.env.local.example` for environment variables
- use `process.env.NEXT_PUBLIC_API_URL` for frontend fetch calls
- document the env file in README
- ignore `.env.local`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run test:e2e` *(fails: playwright not found)*
- `npm run test:coverage` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684873ab87f0832991391b2099338781