### PR TITLE
Update README for Next.js API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,63 @@
 # Agentic AI Commerce
 
-A simple ecommerce app built with Next.js and Express. The backend exposes mock APIs and the frontend uses a mobile-first React design. Tests cover API and UI behavior.
+A simple ecommerce app built with Next.js. Mock APIs are served via built-in Next.js API routes and the frontend uses a mobile-first React design. Tests cover API and UI behavior.
 
 - [Commercetools Apparel Product Model](docs/commercetools-product-model.md)
 - [Architecture Overview](docs/architecture.md)
 
 ## Code Structure
 
-The application is split between a simple Express backend and a Next.js frontend.
-The diagram below highlights the major folders:
+All server functionality lives in Next.js API routes under `src/app/api`. These
+routes call adapters in `src/lib/adapters` which in turn communicate with
+external commerce APIs or return mock data. The diagram below highlights the
+major folders:
 
 ```mermaid
 graph TD
-    subgraph Frontend
-        pages[[pages/]]
-        components[[components/]]
-        lib[[lib/]]
+    subgraph App
+        pages[[src/app/]]
+        api[[src/app/api/]]
+        adapters[[src/lib/adapters/]]
     end
-    subgraph Backend
-        backend[[backend/server.js]]
-    end
-    pages -- use --> components
-    pages -- use --> lib
-    components -- use --> lib
-    pages -- fetch --> backend
+    pages -- call --> api
+    api -- use --> adapters
 ```
 
 Key files:
 
-- [pages/index.js](pages/index.js) – home page listing products
-- [pages/products/[id].js](pages/products/%5Bid%5D.js) – product detail page
-- [components/ProductList.js](components/ProductList.js) – renders product grid
-- [lib/cartContext.js](lib/cartContext.js) – in-memory cart store
-- [backend/server.js](backend/server.js) – mock API endpoints
+- `src/app/page.js` – home page listing products
+- `src/app/products/[id]/page.js` – product detail page
+- `src/lib/cartContext.js` – in-memory cart store
+- `src/app/api/mock/[...mockEndpoints].ts` – local mock API routes
+- `src/lib/adapters/commercetoolsAdapter.ts` – CommerceTools adapter
+- `src/lib/adapters/shopifyAdapter.ts` – Shopify adapter
 
 ## Development
 
 ```bash
 npm install
-npm run dev
 ```
 
-This starts the Express API on port 3001 and Next.js on port 3000.
+Initialize TypeScript (optional but recommended):
+
+```bash
+npx tsc --init
+```
+
+Create a `.env.local` file for API credentials. Example:
+
+```env
+CT_API_URL=https://api.example.com
+SHOPIFY_URL=https://shop.example.com
+SHOPIFY_TOKEN=token
+```
+
+Start the development server:
+
+```bash
+npm run dev
+```
+The app will be available at `http://localhost:3000`.
 
 Run tests:
 


### PR DESCRIPTION
## Summary
- document Next.js API route architecture
- update folder diagram
- add TypeScript and env setup instructions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run test:e2e` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684873b1d8a0832997aaf72511d4622b