### PR TITLE
Add jest config and test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ This starts the Express API on port 3001 and Next.js on port 3000.
 Run tests:
 
 ```bash
-npm test          # unit tests
-npm run test:e2e  # Playwright end-to-end tests
-# Run `npx playwright install` once before running e2e tests.
+npm test             # unit tests
+npm run test:coverage # unit test coverage
+npm run test:e2e     # Playwright end-to-end tests
+npm run cypress      # proxy command for Cypress (uses Playwright)
 ```
+
+End-to-end tests use **Playwright** and should maintain over **70% coverage**.
+Run `npx playwright install` once before executing the E2E suite.

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  transform: {
+    '^.+\\.jsx?$': 'babel-jest',
+  },
+  testMatch: ['**/__tests__/**/*.js'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1',
+    '\\.module\\.css$': 'identity-obj-proxy',
+  },
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 90,
+      lines: 90,
+      statements: 90,
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "backend": "node backend/server.js",
     "test": "jest",
     "test:e2e": "playwright test",
-    "test:wdio": "wdio run wdio.conf.js"
+    "test:wdio": "wdio run wdio.conf.js",
+    "test:coverage": "jest --coverage",
+    "cypress": "echo \"Using Playwright for e2e tests. Run 'npm run test:e2e'\""
   },
   "dependencies": {
     "@playwright/test": "^1.52.0",
@@ -40,21 +42,5 @@
     "@wdio/spec-reporter": "^8.39.0",
     "wdio-chromedriver-service": "^8.1.1",
     "chromedriver": "^125.0.0"
-  },
-  "jest": {
-    "testEnvironment": "jsdom",
-    "setupFilesAfterEnv": [
-      "<rootDir>/jest.setup.js"
-    ],
-    "transform": {
-      "^.+\\.jsx?$": "babel-jest"
-    },
-    "testMatch": [
-      "**/__tests__/**/*.js"
-    ],
-    "moduleNameMapper": {
-      "^@/(.*)$": "<rootDir>/$1",
-      "\\.module\\.css$": "identity-obj-proxy"
-    }
   }
 }


### PR DESCRIPTION
## Summary
- add `jest.config.js` enforcing coverage thresholds
- update npm scripts with `test:coverage` and `cypress` placeholders
- document Playwright e2e coverage expectations

## Testing
- `npm test` *(fails: jest not found)*
- `npm run test:coverage` *(fails: jest not found)*
- `npm run cypress`

------
https://chatgpt.com/codex/tasks/task_e_684873afb1908329ba24cc402feed3d5