### PR TITLE
Enhance backend security headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,10 @@ npm test          # unit tests
 npm run test:e2e  # Playwright end-to-end tests
 # Run `npx playwright install` once before running e2e tests.
 ```
+
+## Security
+
+The Express backend applies [Helmet](https://github.com/helmetjs/helmet) to set
+secure HTTP headers. CORS is restricted to requests from
+`http://localhost:3000` by default. You can override the allowed origin by
+setting the `CLIENT_ORIGIN` environment variable.

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,11 +6,14 @@
  */
 const express = require('express');
 const cors = require('cors');
+const helmet = require('helmet');
 const app = express();
 const port = process.env.PORT || 3001;
 
 app.use(express.json());
-app.use(cors());
+app.use(helmet());
+const allowedOrigin = process.env.CLIENT_ORIGIN || 'http://localhost:3000';
+app.use(cors({ origin: allowedOrigin }));
 
 const products = [
   {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@playwright/test": "^1.52.0",
     "express": "^4.18.2",
+    "helmet": "^7.0.0",
     "cors": "^2.8.5",
     "next": "^13.5.6",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- secure backend server with helmet
- restrict CORS to configurable origin
- document security headers in README

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684873adb4588329bc0f4c8d365ac8e5