### PR TITLE
Fix Babel React runtime

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,7 @@
 module.exports = {
-  presets: ['@babel/preset-env', '@babel/preset-react', '@babel/preset-typescript'],
+  presets: [
+    '@babel/preset-env',
+    ['@babel/preset-react', { runtime: 'automatic' }],
+    '@babel/preset-typescript',
+  ],
 };


### PR DESCRIPTION
## Summary
- enable automatic runtime for React preset

## Testing
- `npm run build` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684882cfcc9c8329bdbe16e41d95ae87